### PR TITLE
Change yarn install to yarn add

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Hardhat plugin to automatically deploy the ERC-1820 Registry contract.
 ## Installation
 
 ```bash
-yarn install hardhat-erc1820
+yarn add --dev hardhat-erc1820
 ```
 
 Import the plugin in your `hardhat.config.js`:


### PR DESCRIPTION
When I start using this plugin I blindly copied the instructions from the README. The command `yarn install hardhat-erc1820` and yarn notified me that I should be using `add` instead.